### PR TITLE
Adding commands for SAAIF item content package creation, status, and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ These are the most basic options when first getting started
 - `-c`: lists the tool commands 
 
 ### Commands
-A new command has been added to the tool.  The command is `create-test-package`.  It requires three command line options
+Command: `create-test-package` 
+Description: Creates an XML test package based on the input spreadsheet
 
 - `-i`: spreadsheet name
 - `-o`: file name to write results
-- `-t`: authorization token
-  
+
 Example usage and output from create-test-package:
 ```
-$ ./tims create-test-package -t 12345-1234-1234-1234-123456789 -i SBAC-IAB-FIXED-G11M-Winter-2017-2018.xlsx -o outputFile.xml
+$ ./tims create-test-package -i SBAC-IAB-FIXED-G11M-Winter-2017-2018.xlsx -o outputFile.xml
 starting...
 
 validated..., submitting request to TIMS
@@ -45,6 +45,66 @@ The results have been written to outputFile.xml
 complete
 $
 ```
+
+Command: `create-saaif-content-package`
+Description: Initiates an SAAIF content package job
+- `-d`: the item id(s) to create SAAIF item packages for, as a comma delimited list with no spaces
+Usage: `create-saaif-content-package -d 1234,5678`
+Example usage and output from create-saaif-content-package:
+```
+$ ./tims create-saaif-content-package -d 209572,209783,209895
+starting...
+
+validated..., submitting request to TIMS translation service
+The content package creation request was successful:
+Content Package Id: 1
+Item Ids: [209572, 209783, 209895]
+
+complete
+
+Process finished with exit code 0
+
+```
+
+Command: `get-saaif-content-package-status`
+Description: Gets the status of an SAAIF content package job 
+Example usage and output from get-saaif-content-package-status:
+```
+$ ./tims get-saaif-content-package-status 1
+starting...
+
+validated..., submitting request to TIMS translation service
+Content Package Status for id 1: COMPLETED
+
+complete
+
+Process finished with exit code 0
+
+```
+
+Command: `get-saaif-content-package-archive`
+Description: Gets the status of an SAAIF content package job 
+Usage: `get-saaif-content-package-status -1`
+
+Command: `get-saaif-content-package-archive`
+- The content package id
+- `-o`: file name to write the archive package
+Example usage and output from get-saaif-content-package-status:
+```
+$ ./tims get-saaif-content-package-archive -o package-1.zip 1
+starting...
+
+validated..., submitting request to TIMS translation service
+The results have been written to package-1.zip
+
+complete
+
+Process finished with exit code 0
+
+
+```
+
+
 
 ## Authorization
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,11 @@ Process finished with exit code 0
 
 ## Authorization
 
-At this time, the user is required to obtain an auth token first. 
+The following SSO-related environment variables need to be defined before running the application:
 
-*This will be changed so the user can either login via the tims-tool, or the user could have credentials in the environment and the tims-tool uses those to get the auth-token.*
-
+TIMS_TOOL_SSO_URL
+TIMS_TOOL_SSO_GRANT_TYPE
+TIMS_TOOL_SSO_USERNAME
+TIMS_TOOL_SSO_PASSWORD
+TIMS_TOOL_SSO_CLIENT_ID
+TIMS_TOOL_SSO_CLIENT_SECRET

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     compile 'org.springframework.boot:spring-boot-starter-aop'
     compile 'org.springframework.boot:spring-boot-starter-web'
     compile 'org.springframework.boot:spring-boot-starter-log4j2'
+    compile 'org.springframework.security.oauth:spring-security-oauth2:2.3.7.RELEASE'
 
     compile 'commons-cli:commons-cli:1.4'
 

--- a/src/main/java/org/opentestsystem/ap/timstool/SecurityProperties.java
+++ b/src/main/java/org/opentestsystem/ap/timstool/SecurityProperties.java
@@ -1,0 +1,44 @@
+package org.opentestsystem.ap.timstool;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * The security application properties.  This are configurable following the spring boot approach of overriding in a
+ * sensible way, a common way being environment variables.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "tims.tool.sso")
+public class SecurityProperties {
+    /**
+     * The SSO username
+     */
+    private String username;
+
+    /**
+     * The SSO password
+     */
+    private String password;
+
+    /**
+     * The SSO client id
+     */
+    private String clientId;
+
+    /**
+     * The SSO client secret
+     */
+    private String clientSecret;
+
+    /**
+     * The SSO host url for obtaining an access token
+     */
+    private String url;
+
+    /**
+     * The SSO Grant type
+     */
+    private String grantType;
+}

--- a/src/main/java/org/opentestsystem/ap/timstool/ToolProperties.java
+++ b/src/main/java/org/opentestsystem/ap/timstool/ToolProperties.java
@@ -30,4 +30,8 @@ public class ToolProperties {
      */
     private String createTestManagementEndpoint;
 
+    /**
+     * The resource path for translation service content packages
+     */
+    private String translationContentPackageEndpoint;
 }

--- a/src/main/java/org/opentestsystem/ap/timstool/command/CommandEnum.java
+++ b/src/main/java/org/opentestsystem/ap/timstool/command/CommandEnum.java
@@ -13,7 +13,10 @@ import java.util.Map;
 @Getter
 public enum CommandEnum {
 
-    CreateTestPackage("create-test-package");
+    CreateTestPackage("create-test-package"),
+    CreateItemContentPackage("create-saaif-content-package"),
+    GetItemContentStatusCommand("get-saaif-content-package-status"),
+    GetItemContentCommand("get-saaif-content-package-archive");
 
     private String text;
 

--- a/src/main/java/org/opentestsystem/ap/timstool/command/CreateItemContentPackageCommand.java
+++ b/src/main/java/org/opentestsystem/ap/timstool/command/CreateItemContentPackageCommand.java
@@ -1,0 +1,95 @@
+package org.opentestsystem.ap.timstool.command;
+
+import lombok.extern.slf4j.Slf4j;
+import org.opentestsystem.ap.timstool.ToolProperties;
+import org.opentestsystem.ap.timstool.commandline.ToolCommandLine;
+import org.opentestsystem.ap.timstool.exception.UsageException;
+import org.opentestsystem.ap.timstool.model.CreateItemContentPackageResponse;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.OAuth2RestOperations;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class CreateItemContentPackageCommand implements Command {
+    private final ToolProperties properties;
+
+    private final OAuth2RestOperations restTemplate;
+
+    private final String commandName;
+
+    public CreateItemContentPackageCommand(ToolProperties properties, OAuth2RestOperations restTemplate) {
+        this.properties = properties;
+        this.restTemplate = restTemplate;
+        this.commandName = CommandEnum.CreateItemContentPackage.getText();
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void execute(ToolCommandLine commandLine) {
+        this.validate(commandLine);
+        commandLine.printMessage("validated..., submitting request to TIMS translation service");
+        this.submitRequest(commandLine);
+    }
+
+    // ------------------------------------------------------------------------
+
+    private void submitRequest(ToolCommandLine commandLine) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<CreateItemContentPackageRequest> requestEntity = new HttpEntity<>(
+            new CreateItemContentPackageRequest(commandLine.getItemIds()), headers);
+
+        ResponseEntity<CreateItemContentPackageResponse> response = this.restTemplate
+            .postForEntity(
+                String.format("%s/%s", this.properties.getApiGatewayUrl(),
+                    this.properties.getTranslationContentPackageEndpoint()),
+                requestEntity,
+                CreateItemContentPackageResponse.class);
+
+        if (response.getStatusCode() == HttpStatus.CREATED) {
+            commandLine.printMessage("The content package creation request was successful:");
+            commandLine.printMessage(String
+                .format("Content Package Id: %s \nItem Ids: %s", response.getBody().getId(),
+                    response.getBody().getItemIds()));
+        } else {
+            commandLine
+                .printMessage(String.format("The content package creation request failed: \n %s", response.toString()));
+        }
+    }
+
+    private void validate(ToolCommandLine commandLine) {
+        if (commandLine.getItemIds() == null || commandLine.getItemIds().isEmpty()) {
+            throw new UsageException(
+                String.format("Command %s requires a list of item ids to be specified.", commandName));
+        }
+    }
+
+    private class CreateItemContentPackageRequest {
+        private String format;
+        private List<String> itemIds;
+
+        private CreateItemContentPackageRequest() {
+        }
+
+        CreateItemContentPackageRequest(final List<String> itemIds) {
+            this.itemIds = itemIds;
+            this.format = "SAAIF";
+        }
+
+        public String getFormat() {
+            return format;
+        }
+
+        public List<String> getItemIds() {
+            return itemIds;
+        }
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/timstool/command/CreateTestPackageCommand.java
+++ b/src/main/java/org/opentestsystem/ap/timstool/command/CreateTestPackageCommand.java
@@ -8,10 +8,10 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.OAuth2RestOperations;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
 
 import java.nio.file.Path;
 
@@ -24,11 +24,11 @@ public class CreateTestPackageCommand implements Command {
 
     private final ToolProperties properties;
 
-    private final RestTemplate restTemplate;
+    private final OAuth2RestOperations restTemplate;
 
     private final String commandName;
 
-    public CreateTestPackageCommand(ToolProperties properties, RestTemplate restTemplate) {
+    public CreateTestPackageCommand(ToolProperties properties, OAuth2RestOperations restTemplate) {
         this.properties = properties;
         this.restTemplate = restTemplate;
         this.commandName = CommandEnum.CreateTestPackage.getText();
@@ -48,7 +48,6 @@ public class CreateTestPackageCommand implements Command {
     private void submitRequest(ToolCommandLine commandLine) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
-        headers.set("Authorization", "Bearer " + commandLine.getAuthToken());
 
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
         body.add("file", commandLine.getInputFileAsResource());
@@ -56,7 +55,10 @@ public class CreateTestPackageCommand implements Command {
         HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 
         ResponseEntity<String> response = this.restTemplate
-            .postForEntity(this.properties.getCreateTestManagementEndpoint(), requestEntity, String.class);
+            .postForEntity(String.format("%s/%s", this.properties.getApiGatewayUrl(),
+                this.properties.getCreateTestManagementEndpoint()),
+                requestEntity,
+                String.class);
 
         Path outputFile = commandLine.writeToOutputFile(response.getBody());
         commandLine.printMessage("The results have been written to %s", outputFile.toString());
@@ -68,10 +70,6 @@ public class CreateTestPackageCommand implements Command {
         }
         if (!commandLine.hasOutputFile()) {
             throw new UsageException(String.format("Command %s requires an output file be specified.", commandName));
-        }
-        if (!commandLine.hasAuthToken()) {
-            throw new UsageException(
-                String.format("Command %s requires an authorization token be specified.", commandName));
         }
     }
 }

--- a/src/main/java/org/opentestsystem/ap/timstool/command/GetItemContentPackageCommand.java
+++ b/src/main/java/org/opentestsystem/ap/timstool/command/GetItemContentPackageCommand.java
@@ -1,0 +1,79 @@
+package org.opentestsystem.ap.timstool.command;
+
+import lombok.extern.slf4j.Slf4j;
+import org.opentestsystem.ap.timstool.ToolProperties;
+import org.opentestsystem.ap.timstool.commandline.ToolCommandLine;
+import org.opentestsystem.ap.timstool.exception.UsageException;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.OAuth2RestOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+
+import java.nio.file.Path;
+
+@Slf4j
+@Component
+public class GetItemContentPackageCommand implements Command {
+    private final ToolProperties properties;
+
+    private final OAuth2RestOperations restTemplate;
+
+    private final String commandName;
+
+    public GetItemContentPackageCommand(ToolProperties properties, OAuth2RestOperations restTemplate) {
+        this.properties = properties;
+        this.restTemplate = restTemplate;
+        this.commandName = CommandEnum.GetItemContentCommand.getText();
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void execute(ToolCommandLine commandLine) {
+        this.validate(commandLine);
+        commandLine.printMessage("validated..., submitting request to TIMS translation service");
+        this.submitRequest(commandLine);
+    }
+
+    // ------------------------------------------------------------------------
+
+    private void submitRequest(ToolCommandLine commandLine) {
+        HttpHeaders headers = new HttpHeaders();
+
+        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(headers);
+        long contentPackageId = commandLine.getContentPackageId();
+
+        ResponseEntity<byte[]> response = this.restTemplate
+            .exchange(
+                String.format("%s/%s/%s/content", this.properties.getApiGatewayUrl(),
+                    this.properties.getTranslationContentPackageEndpoint(), contentPackageId),
+                HttpMethod.GET,
+                requestEntity,
+                byte[].class
+            );
+
+        if (response.getStatusCode() == HttpStatus.OK) {
+            Path outputFile = commandLine.writeToOutputFile(response.getBody());
+            commandLine.printMessage("The results have been written to %s", outputFile.toString());
+        } else {
+            commandLine
+                .printMessage(
+                    String.format("Could not fetch item content for content package id %s: \n %s", contentPackageId,
+                        response.toString()));
+        }
+    }
+
+    private void validate(ToolCommandLine commandLine) {
+        if (!commandLine.hasOutputFile()) {
+            throw new UsageException(String.format("Command %s requires an output file be specified.", commandName));
+        }
+        if (commandLine.getContentPackageId() == null) {
+            throw new UsageException(
+                String.format("Command %s requires a content package id be specified.", commandName));
+        }
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/timstool/command/GetItemContentPackageStatusCommand.java
+++ b/src/main/java/org/opentestsystem/ap/timstool/command/GetItemContentPackageStatusCommand.java
@@ -1,0 +1,75 @@
+package org.opentestsystem.ap.timstool.command;
+
+import lombok.extern.slf4j.Slf4j;
+import org.opentestsystem.ap.timstool.ToolProperties;
+import org.opentestsystem.ap.timstool.commandline.ToolCommandLine;
+import org.opentestsystem.ap.timstool.exception.UsageException;
+import org.opentestsystem.ap.timstool.model.CreateItemContentPackageResponse;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.OAuth2RestOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+
+@Slf4j
+@Component
+public class GetItemContentPackageStatusCommand implements Command {
+    private final ToolProperties properties;
+
+    private final OAuth2RestOperations restTemplate;
+
+    private final String commandName;
+
+    public GetItemContentPackageStatusCommand(ToolProperties properties, OAuth2RestOperations restTemplate) {
+        this.properties = properties;
+        this.restTemplate = restTemplate;
+        this.commandName = CommandEnum.GetItemContentStatusCommand.getText();
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void execute(ToolCommandLine commandLine) {
+        this.validate(commandLine);
+        commandLine.printMessage("validated..., submitting request to TIMS translation service");
+        this.submitRequest(commandLine);
+    }
+
+    // ------------------------------------------------------------------------
+
+    private void submitRequest(ToolCommandLine commandLine) {
+        HttpHeaders headers = new HttpHeaders();
+
+        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(headers);
+        long contentPackageId = commandLine.getContentPackageId();
+
+        ResponseEntity<CreateItemContentPackageResponse> response = this.restTemplate
+            .exchange(
+                String.format("%s/%s/%s", this.properties.getApiGatewayUrl(),
+                    this.properties.getTranslationContentPackageEndpoint(), contentPackageId),
+                HttpMethod.GET,
+                requestEntity,
+                CreateItemContentPackageResponse.class
+            );
+
+        if (response.getStatusCode() == HttpStatus.OK) {
+            commandLine.printMessage(String
+                .format("Content Package Status for id %s: %s", contentPackageId, response.getBody().getStatus()));
+        } else {
+            commandLine
+                .printMessage(
+                    String.format("Could not fetch item content for content package id %s: \n %s", contentPackageId,
+                        response.toString()));
+        }
+    }
+
+    private void validate(ToolCommandLine commandLine) {
+        if (commandLine.getContentPackageId() == null) {
+            throw new UsageException(
+                String.format("Command %s requires a content package id be specified.", commandName));
+        }
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/timstool/commandline/ToolCommandLine.java
+++ b/src/main/java/org/opentestsystem/ap/timstool/commandline/ToolCommandLine.java
@@ -10,6 +10,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.ParseException;
 import org.opentestsystem.ap.timstool.ToolProperties;
 import org.opentestsystem.ap.timstool.command.Command;
+import org.opentestsystem.ap.timstool.command.CommandEnum;
 import org.opentestsystem.ap.timstool.exception.UsageException;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
@@ -20,6 +21,9 @@ import java.nio.file.Files;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Consumer;
 
 /**
@@ -102,6 +106,17 @@ public class ToolCommandLine {
         return new FileSystemResource(inputFile.toFile());
     }
 
+    public List<String> getItemIds() {
+        String itemIdStr = commandLine.getOptionValue("d");
+        return itemIdStr != null
+            ? Arrays.asList(itemIdStr.replaceAll("\\s", "").split(",")) //remove whitespace
+            : new ArrayList<>();
+    }
+
+    public Long getContentPackageId() {
+        return commandLine.getArgs().length < 2 ? null : Long.valueOf(commandLine.getArgs()[1]);
+    }
+
     public String getOutputFile() {
         return this.getOptionValue(this.toolOptions.getOutputFile());
     }
@@ -123,8 +138,21 @@ public class ToolCommandLine {
         }
     }
 
-    public String getAuthToken() {
-        return this.getOptionValue(this.toolOptions.getAuthToken());
+    public Path writeToOutputFile(byte[] content, OpenOption... options) {
+        String outputFileName = this.getOutputFile();
+        Path outputFilePath = Paths.get(outputFileName);
+        try {
+            Files.write(outputFilePath, content, options);
+            return outputFilePath;
+        } catch (IOException e) {
+            CONSOLE.println("Failed to write content to " + outputFilePath.toString());
+            CONSOLE.println("--- BEGIN CONTENT ---");
+            CONSOLE.println();
+            CONSOLE.println(content);
+            CONSOLE.println();
+            CONSOLE.println("--- END CONTENT ---");
+            throw new RuntimeException("Error writing to output file: " + e.getMessage(), e);
+        }
     }
 
     private String getOptionValue(Option option) {
@@ -138,10 +166,13 @@ public class ToolCommandLine {
         if (this.isCommandMissing()) {
             throw new UsageException("No command was given, one command is required.");
         }
-        if (this.commandLine.getArgList().size() > 1) {
+
+        String command = this.commandName();
+
+        if (this.commandLine.getArgList().size() > 1 && command.equals(CommandEnum.CreateTestPackage.getText())) {
             throw new UsageException("More than one command was given, only one command is allowed.");
         }
-        String command = this.commandName();
+
         if (this.toolCommands.isNotValid(command)) {
             throw new UsageException(String.format("Command '%s' is not valid", command));
         }
@@ -161,10 +192,6 @@ public class ToolCommandLine {
 
     public boolean hasOutputFile() {
         return this.hasOption(this.toolOptions.getOutputFile());
-    }
-
-    public boolean hasAuthToken() {
-        return this.hasOption(this.toolOptions.getAuthToken());
     }
 
     public boolean isCommandMissing() {

--- a/src/main/java/org/opentestsystem/ap/timstool/commandline/ToolOptions.java
+++ b/src/main/java/org/opentestsystem/ap/timstool/commandline/ToolOptions.java
@@ -35,9 +35,9 @@ public class ToolOptions {
     private final Option outputFile;
 
     /**
-     * The authorization token used when calling the gateway.
+     * The item ids to create SAAIF item content for
      */
-    private final Option authToken;
+    private final Option itemIds;
 
     public ToolOptions() {
         this.help = Option.builder("h").longOpt("help")
@@ -54,15 +54,15 @@ public class ToolOptions {
             .hasArg().argName("file")
             .desc("Specifies the output file.").build();
 
-        this.authToken = Option.builder("t").longOpt("token")
-            .hasArg().argName("auth-token")
-            .desc("Specifies the authorization token.").build();
+        this.itemIds = Option.builder("d").longOpt("itemIds")
+            .hasArg().argName("item-ids")
+            .desc("Specifies the item ids to create test packages for.").build();
 
         this.options = new Options();
         this.options.addOption(this.help);
         this.options.addOption(this.commands);
         this.options.addOption(this.inputFile);
         this.options.addOption(this.outputFile);
-        this.options.addOption(this.authToken);
+        this.options.addOption(this.itemIds);
     }
 }

--- a/src/main/java/org/opentestsystem/ap/timstool/configuration/ToolCommandConfiguration.java
+++ b/src/main/java/org/opentestsystem/ap/timstool/configuration/ToolCommandConfiguration.java
@@ -3,7 +3,10 @@ package org.opentestsystem.ap.timstool.configuration;
 import lombok.extern.slf4j.Slf4j;
 import org.opentestsystem.ap.timstool.command.Command;
 import org.opentestsystem.ap.timstool.command.CommandEnum;
+import org.opentestsystem.ap.timstool.command.CreateItemContentPackageCommand;
 import org.opentestsystem.ap.timstool.command.CreateTestPackageCommand;
+import org.opentestsystem.ap.timstool.command.GetItemContentPackageCommand;
+import org.opentestsystem.ap.timstool.command.GetItemContentPackageStatusCommand;
 import org.opentestsystem.ap.timstool.commandline.ToolCommands;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -22,8 +25,20 @@ public class ToolCommandConfiguration {
 
     private final CreateTestPackageCommand createTestPackageCommand;
 
-    public ToolCommandConfiguration(CreateTestPackageCommand createTestPackageCommand) {
+    private final CreateItemContentPackageCommand createItemContentPackageCommand;
+
+    private final GetItemContentPackageStatusCommand getItemContentPackageStatusCommand;
+
+    private final GetItemContentPackageCommand getItemContentPackageCommand;
+
+    public ToolCommandConfiguration(CreateTestPackageCommand createTestPackageCommand,
+                                    CreateItemContentPackageCommand createItemContentPackageCommand,
+                                    GetItemContentPackageStatusCommand getItemContentPackageStatusCommand,
+                                    GetItemContentPackageCommand getItemContentPackageCommand) {
         this.createTestPackageCommand = createTestPackageCommand;
+        this.createItemContentPackageCommand = createItemContentPackageCommand;
+        this.getItemContentPackageStatusCommand = getItemContentPackageStatusCommand;
+        this.getItemContentPackageCommand = getItemContentPackageCommand;
     }
 
     @Bean
@@ -33,6 +48,9 @@ public class ToolCommandConfiguration {
 
         Map<CommandEnum, Command> commands = new HashMap<>();
         commands.put(CommandEnum.CreateTestPackage, this.createTestPackageCommand);
+        commands.put(CommandEnum.CreateItemContentPackage, this.createItemContentPackageCommand);
+        commands.put(CommandEnum.GetItemContentStatusCommand, this.getItemContentPackageStatusCommand);
+        commands.put(CommandEnum.GetItemContentCommand, this.getItemContentPackageCommand);
 
         return new ToolCommands(commands);
     }

--- a/src/main/java/org/opentestsystem/ap/timstool/configuration/ToolConfiguration.java
+++ b/src/main/java/org/opentestsystem/ap/timstool/configuration/ToolConfiguration.java
@@ -1,7 +1,9 @@
 package org.opentestsystem.ap.timstool.configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.opentestsystem.ap.timstool.SecurityProperties;
 import org.opentestsystem.ap.timstool.ToolProperties;
 import org.opentestsystem.ap.timstool.gateway.GatewayResponseErrorHandler;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -9,33 +11,61 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.security.oauth2.client.OAuth2RestOperations;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.client.resource.BaseOAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.client.token.grant.password.ResourceOwnerPasswordResourceDetails;
+import org.springframework.security.oauth2.common.AuthenticationScheme;
 import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @Configuration
-@EnableConfigurationProperties({ToolProperties.class})
+@EnableConfigurationProperties({ToolProperties.class, SecurityProperties.class})
 public class ToolConfiguration {
 
     private final ToolProperties properties;
 
+    private final SecurityProperties securityProperties;
+
     private final CloseableHttpClient httpClient;
 
     public ToolConfiguration(ToolProperties properties,
+                             SecurityProperties securityProperties,
                              CloseableHttpClient httpClient) {
         this.properties = properties;
+        this.securityProperties = securityProperties;
         this.httpClient = httpClient;
     }
 
     @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder builder) {
-        log.debug("Create bean restTemplate");
-        return builder
-            .rootUri(properties.getApiGatewayUrl())
-            .requestFactory(clientHttpRequestFactory())
-            .errorHandler(new GatewayResponseErrorHandler())
-            .build();
+    public OAuth2RestOperations oAuth2RestTemplate() {
+        OAuth2RestTemplate restTemplate = new OAuth2RestTemplate(oauth2ProtectedResourceDetails());
+        restTemplate.setRequestFactory(clientHttpRequestFactory());
+        restTemplate.setErrorHandler(new GatewayResponseErrorHandler());
+        return restTemplate;
+    }
+
+    private OAuth2ProtectedResourceDetails oauth2ProtectedResourceDetails() {
+        final ResourceOwnerPasswordResourceDetails resourceDetails =
+            new ResourceOwnerPasswordResourceDetails();
+
+        resourceDetails.setUsername(securityProperties.getUsername());
+        resourceDetails.setPassword(securityProperties.getPassword());
+        resourceDetails.setClientId(securityProperties.getClientId());
+        resourceDetails.setClientSecret(securityProperties.getClientSecret());
+        resourceDetails.setAccessTokenUri(securityProperties.getUrl());
+        resourceDetails.setGrantType(securityProperties.getGrantType());
+
+        return resourceDetails;
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return Jackson2ObjectMapperBuilder.json().build();
     }
 
     @Bean

--- a/src/main/java/org/opentestsystem/ap/timstool/model/CreateItemContentPackageResponse.java
+++ b/src/main/java/org/opentestsystem/ap/timstool/model/CreateItemContentPackageResponse.java
@@ -1,0 +1,45 @@
+package org.opentestsystem.ap.timstool.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CreateItemContentPackageResponse {
+    private long id;
+    private List<String> itemIds;
+    private String status;
+
+    private CreateItemContentPackageResponse() {
+    }
+
+    public CreateItemContentPackageResponse(long id, List<String> itemIds, String status) {
+        this.id = id;
+        this.itemIds = itemIds;
+        this.status = status;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public List<String> getItemIds() {
+        return itemIds;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public void setItemIds(List<String> itemIds) {
+        this.itemIds = itemIds;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,9 +29,9 @@ tims:
     createTestManagementEndpoint: "/api/tms/package/generate"
     translationContentPackageEndpoint: "/api/translation/content-packages"
     sso:
-      username: ${tims.tool.sso.username}
-      password: ${tims.tool.sso.password}
-      clientId: ${tims.tool.sso.client-id}
-      clientSecret: ${tims.tool.sso.client-secret}
-      grantType: ${tims.tool.sso.grant-type}
-      url: ${tims.tool.sso.url}
+      username: \${TIMS_TOOL_SSO_USERNAME}
+      password: \${TIMS_TOOL_SSO_PASSWORD}
+      clientId: \${TIMS_TOOL_SSO_CLIENT_ID}
+      clientSecret: \${TIMS_TOOL_SSO_CLIENT_SECRET}
+      grantType: \${TIMS_TOOL_SSO_GRANT_TYPE}
+      url: \${TIMS_TOOL_SSO_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,3 +27,11 @@ tims:
     appScriptName: "./tims"
     apiGatewayUrl: "http://localhost:8180"
     createTestManagementEndpoint: "/api/tms/package/generate"
+    translationContentPackageEndpoint: "/api/translation/content-packages"
+    sso:
+      username: ${tims.tool.sso.username}
+      password: ${tims.tool.sso.password}
+      clientId: ${tims.tool.sso.client-id}
+      clientSecret: ${tims.tool.sso.client-secret}
+      grantType: ${tims.tool.sso.grant-type}
+      url: ${tims.tool.sso.url}

--- a/src/test/java/org/opentestsystem/ap/timstool/command/CreateItemContentPackageCommandTest.java
+++ b/src/test/java/org/opentestsystem/ap/timstool/command/CreateItemContentPackageCommandTest.java
@@ -1,0 +1,140 @@
+package org.opentestsystem.ap.timstool.command;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.timstool.ToolProperties;
+import org.opentestsystem.ap.timstool.commandline.ToolCommandLine;
+import org.opentestsystem.ap.timstool.commandline.ToolCommands;
+import org.opentestsystem.ap.timstool.exception.UsageException;
+import org.opentestsystem.ap.timstool.model.CreateItemContentPackageResponse;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.OAuth2RestOperations;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CreateItemContentPackageCommandTest {
+
+    static final String COMMAND_NAME = CommandEnum.CreateItemContentPackage.getText();
+
+    private ToolProperties toolProperties;
+
+    private ToolCommandLine toolCommandLine;
+
+    private CreateItemContentPackageCommand command;
+
+    @Mock
+    private ToolCommands mockCommandLineCommands;
+
+    @Mock
+    private OAuth2RestOperations mockRestTemplate;
+
+    @Mock
+    private ResponseEntity mockResponseEntity;
+
+    private ArgumentCaptor<HttpEntity> argumentCaptor;
+
+    @Before
+    public void setUp() {
+        toolProperties = new ToolProperties();
+        toolProperties.setAppScriptName("tims");
+        toolProperties.setApiGatewayUrl("https:/api-gateway");
+        toolProperties.setTranslationContentPackageEndpoint("/translation/content-packages");
+
+        command = new CreateItemContentPackageCommand(toolProperties, mockRestTemplate);
+
+        argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+
+        toolCommandLine = new ToolCommandLine(toolProperties, mockCommandLineCommands);
+    }
+
+    @Test
+    public void testExecuteSuccess() {
+        when(mockResponseEntity.getBody()).thenReturn(
+            new CreateItemContentPackageResponse(1, Arrays.asList("1234","5678"), "SUCCESS"));
+        when(mockResponseEntity.getStatusCode()).thenReturn(HttpStatus.CREATED);
+        when(
+            mockRestTemplate.postForEntity(
+                eq(String.format("%s/%s", toolProperties.getApiGatewayUrl(), toolProperties.getTranslationContentPackageEndpoint())),
+                argumentCaptor.capture(),
+                eq(CreateItemContentPackageResponse.class)))
+            .thenReturn(mockResponseEntity);
+
+        toolCommandLine.applyArgs(
+            COMMAND_NAME,
+            "-d", "1234,5678");
+
+        command.execute(toolCommandLine);
+
+        assertThat(argumentCaptor.getValue().getHeaders().getContentType().toString()).isEqualTo("application/json");
+    }
+
+    @Test
+    public void testExecuteSuccessWithError() {
+        when(mockResponseEntity.getBody()).thenReturn(
+            new CreateItemContentPackageResponse(1, Arrays.asList("1234","5678"), "FAILURE"));
+        when(mockResponseEntity.getStatusCode()).thenReturn(HttpStatus.UNAUTHORIZED);
+        when(
+            mockRestTemplate.postForEntity(
+                eq(String.format("%s/%s", toolProperties.getApiGatewayUrl(), toolProperties.getTranslationContentPackageEndpoint())),
+                argumentCaptor.capture(),
+                eq(CreateItemContentPackageResponse.class)))
+            .thenReturn(mockResponseEntity);
+
+        toolCommandLine.applyArgs(
+            COMMAND_NAME,
+            "-d", "1234,5678");
+
+        command.execute(toolCommandLine);
+
+        assertThat(argumentCaptor.getValue().getHeaders().getContentType().toString()).isEqualTo("application/json");
+    }
+
+    @Test
+    public void testExecuteSuccessWithWhitespace() {
+        when(mockResponseEntity.getBody()).thenReturn(
+            new CreateItemContentPackageResponse(1, Arrays.asList("1234","5678"), "SUCCESS"));
+        when(mockResponseEntity.getStatusCode()).thenReturn(HttpStatus.CREATED);
+        when(
+            mockRestTemplate.postForEntity(
+                eq(String.format("%s/%s", toolProperties.getApiGatewayUrl(), toolProperties.getTranslationContentPackageEndpoint())),
+                argumentCaptor.capture(),
+                eq(CreateItemContentPackageResponse.class)))
+            .thenReturn(mockResponseEntity);
+
+        toolCommandLine.applyArgs(
+            COMMAND_NAME,
+            "-d", "1234,     5678");
+
+        command.execute(toolCommandLine);
+
+        assertThat(argumentCaptor.getValue().getHeaders().getContentType().toString()).isEqualTo("application/json");
+    }
+
+    @Test
+    public void testWhenNoItemIdsOptionGiven() {
+        toolCommandLine.applyArgs(
+            COMMAND_NAME);
+        assertCommandValidation(toolCommandLine, "Command create-saaif-content-package requires a list of item ids to be specified.");
+    }
+
+    void assertCommandValidation(ToolCommandLine toolCommandLine, String expectedErrorMessage) {
+        try {
+            command.execute(toolCommandLine);
+            Assert.fail("Expected UsageException");
+        } catch (UsageException e) {
+            assertThat(e.getMessage()).isEqualTo(expectedErrorMessage);
+        }
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/timstool/command/GetItemContentPackageCommandTest.java
+++ b/src/test/java/org/opentestsystem/ap/timstool/command/GetItemContentPackageCommandTest.java
@@ -12,11 +12,11 @@ import org.opentestsystem.ap.timstool.ToolProperties;
 import org.opentestsystem.ap.timstool.commandline.ToolCommandLine;
 import org.opentestsystem.ap.timstool.commandline.ToolCommands;
 import org.opentestsystem.ap.timstool.exception.UsageException;
-import org.springframework.core.io.Resource;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.OAuth2RestOperations;
-import org.springframework.util.MultiValueMap;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -24,15 +24,14 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.eq;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CreateTestPackageCommandTest {
+public class GetItemContentPackageCommandTest {
+    static final String COMMAND_NAME = CommandEnum.GetItemContentCommand.getText();
 
-    static final String COMMAND_NAME = CommandEnum.CreateTestPackage.getText();
-
-    static final String OUTPUT_FILE_NAME = "output.xml";
+    static final String OUTPUT_FILE_NAME = "output.zip";
 
     static final Path OUT_PUT_FILE_PATH = Paths.get(OUTPUT_FILE_NAME);
 
@@ -40,16 +39,16 @@ public class CreateTestPackageCommandTest {
 
     ToolCommandLine toolCommandLine;
 
-    CreateTestPackageCommand command;
+    GetItemContentPackageCommand command;
 
     @Mock
-    ToolCommands commandLineCommands;
+    ToolCommands mockCommandLineCommands;
 
     @Mock
-    OAuth2RestOperations restTemplate;
+    OAuth2RestOperations mockRestTemplate;
 
     @Mock
-    ResponseEntity responseEntity;
+    ResponseEntity mockResponseEntity;
 
     ArgumentCaptor<HttpEntity> argumentCaptor;
 
@@ -58,13 +57,13 @@ public class CreateTestPackageCommandTest {
         toolProperties = new ToolProperties();
         toolProperties.setAppScriptName("tims");
         toolProperties.setApiGatewayUrl("https:/api-gateway");
-        toolProperties.setCreateTestManagementEndpoint("/tms/create/test/package");
+        toolProperties.setTranslationContentPackageEndpoint("translation/content-packages");
 
-        command = new CreateTestPackageCommand(toolProperties, restTemplate);
+        command = new GetItemContentPackageCommand(toolProperties, mockRestTemplate);
 
         argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
 
-        toolCommandLine = new ToolCommandLine(toolProperties, commandLineCommands);
+        toolCommandLine = new ToolCommandLine(toolProperties, mockCommandLineCommands);
 
         deleteOutputFile();
     }
@@ -82,45 +81,44 @@ public class CreateTestPackageCommandTest {
 
     @Test
     public void testExecuteSuccess() {
-        when(responseEntity.getBody()).thenReturn("<report>SUCCESS</report>");
+        final long contentPackageId = 1;
+        when(mockResponseEntity.getBody()).thenReturn("SUCCESS".getBytes());
+        when(mockResponseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
         when(
-            restTemplate.postForEntity(
-                eq(String.format("%s/%s", toolProperties.getApiGatewayUrl(), toolProperties.getCreateTestManagementEndpoint())),
+            mockRestTemplate.exchange(
+                eq(String.format("%s/%s/%s/content", toolProperties.getApiGatewayUrl(),
+                    toolProperties.getTranslationContentPackageEndpoint(), contentPackageId)),
+                eq(HttpMethod.GET),
                 argumentCaptor.capture(),
-                eq(String.class)))
-            .thenReturn(responseEntity);
+                eq(byte[].class)))
+            .thenReturn(mockResponseEntity);
 
         toolCommandLine.applyArgs(
             COMMAND_NAME,
-            "-i", "input.txt",
-            "-o", "output.xml");
+            "-o", "output.zip",
+            String.valueOf(contentPackageId));
 
         command.execute(toolCommandLine);
 
         assertThat(Files.exists(OUT_PUT_FILE_PATH)).isTrue();
-
-        assertThat(argumentCaptor.getValue().getHeaders().getContentType().toString()).isEqualTo("multipart/form-data");
-
-        MultiValueMap<String, Object> body = (MultiValueMap<String, Object>) argumentCaptor.getValue().getBody();
-
-        assertThat(body.get("file")).hasSize(1);
-        assertThat(body.get("file").get(0)).isInstanceOf(Resource.class);
-    }
-
-    @Test
-    public void testWhenNoInputFileOptionGiven() {
-        toolCommandLine.applyArgs(
-            COMMAND_NAME,
-            "-o", "output.txt");
-        assertCommandValidation(toolCommandLine, "Command create-test-package requires an input file be specified.");
     }
 
     @Test
     public void testWhenNoOutputFileOptionGiven() {
         toolCommandLine.applyArgs(
             COMMAND_NAME,
-            "-i", "input.txt");
-        assertCommandValidation(toolCommandLine, "Command create-test-package requires an output file be specified.");
+            "1");
+        assertCommandValidation(toolCommandLine,
+            "Command get-saaif-content-package-archive requires an output file be specified.");
+    }
+
+    @Test
+    public void testWhenNoContentPackageArgGiven() {
+        toolCommandLine.applyArgs(
+            COMMAND_NAME,
+            "-o", "output.zip");
+        assertCommandValidation(toolCommandLine,
+            "Command get-saaif-content-package-archive requires a content package id be specified.");
     }
 
     void assertCommandValidation(ToolCommandLine toolCommandLine, String expectedErrorMessage) {

--- a/src/test/java/org/opentestsystem/ap/timstool/command/GetItemContentPackageStatusCommandTest.java
+++ b/src/test/java/org/opentestsystem/ap/timstool/command/GetItemContentPackageStatusCommandTest.java
@@ -1,0 +1,103 @@
+package org.opentestsystem.ap.timstool.command;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.timstool.ToolProperties;
+import org.opentestsystem.ap.timstool.commandline.ToolCommandLine;
+import org.opentestsystem.ap.timstool.commandline.ToolCommands;
+import org.opentestsystem.ap.timstool.exception.UsageException;
+import org.opentestsystem.ap.timstool.model.CreateItemContentPackageResponse;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.OAuth2RestOperations;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GetItemContentPackageStatusCommandTest {
+
+    static final String COMMAND_NAME = CommandEnum.GetItemContentStatusCommand.getText();
+
+    private ToolProperties toolProperties;
+
+    private ToolCommandLine toolCommandLine;
+
+    private GetItemContentPackageStatusCommand command;
+
+    @Mock
+    private ToolCommands mockCommandLineCommands;
+
+    @Mock
+    private OAuth2RestOperations mockRestTemplate;
+
+    @Mock
+    private ResponseEntity mockResponseEntity;
+
+    private ArgumentCaptor<HttpEntity> argumentCaptor;
+
+    @Before
+    public void setUp() {
+        toolProperties = new ToolProperties();
+        toolProperties.setAppScriptName("tims");
+        toolProperties.setApiGatewayUrl("https:/api-gateway");
+        toolProperties.setTranslationContentPackageEndpoint("/translation/content-packages");
+
+        command = new GetItemContentPackageStatusCommand(toolProperties, mockRestTemplate);
+
+        argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+
+        toolCommandLine = new ToolCommandLine(toolProperties, mockCommandLineCommands);
+    }
+
+    @Test
+    public void testExecuteSuccess() {
+        final long contentPackageId = 1;
+        when(mockResponseEntity.getBody()).thenReturn(
+            new CreateItemContentPackageResponse(1, Arrays.asList("1234", "5678"), "SUCCESS"));
+        when(mockResponseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
+        when(
+            mockRestTemplate.exchange(
+                eq(String.format("%s/%s/%s", toolProperties.getApiGatewayUrl(),
+                    toolProperties.getTranslationContentPackageEndpoint(), contentPackageId)),
+                eq(HttpMethod.GET),
+                argumentCaptor.capture(),
+                eq(CreateItemContentPackageResponse.class)))
+            .thenReturn(mockResponseEntity);
+
+        toolCommandLine.applyArgs(
+            COMMAND_NAME,
+            String.valueOf(contentPackageId));
+
+        command.execute(toolCommandLine);
+    }
+
+    @Test
+    public void testWhenNoContentPackageArgGiven() {
+        toolCommandLine.applyArgs(
+            COMMAND_NAME,
+            "-o", "output.zip");
+        assertCommandValidation(toolCommandLine,
+            "Command get-saaif-content-package-status requires a content package id be specified.");
+    }
+
+
+    void assertCommandValidation(ToolCommandLine toolCommandLine, String expectedErrorMessage) {
+        try {
+            command.execute(toolCommandLine);
+            Assert.fail("Expected UsageException");
+        } catch (UsageException e) {
+            assertThat(e.getMessage()).isEqualTo(expectedErrorMessage);
+        }
+    }
+}

--- a/src/test/java/org/opentestsystem/ap/timstool/commandline/ToolCommandLineTest.java
+++ b/src/test/java/org/opentestsystem/ap/timstool/commandline/ToolCommandLineTest.java
@@ -134,13 +134,13 @@ public class ToolCommandLineTest {
 
     @Test
     public void testGetCommandName() {
-        toolCommandLine.applyArgs(COMMAND_NAME, "-t", "auth123");
+        toolCommandLine.applyArgs(COMMAND_NAME, "-d", "auth123");
         assertThat(toolCommandLine.getCommandName()).isEqualTo(COMMAND_NAME);
     }
 
     @Test
     public void testGetCommandNameWhenItsInvalid() {
-        toolCommandLine.applyArgs(COMMAND_NAME + "_invalid", "-t", "auth123");
+        toolCommandLine.applyArgs(COMMAND_NAME + "_invalid", "-d", "auth123");
         try {
             toolCommandLine.getCommandName();
             Assert.fail("Expected usage exception");
@@ -150,19 +150,12 @@ public class ToolCommandLineTest {
     }
 
     @Test
-    public void testToolCommandLineAuthOption() {
-        toolCommandLine.applyArgs(COMMAND_NAME, "-t", "auth123");
-        assertThat(toolCommandLine.hasAuthToken()).isTrue();
-        assertThat(toolCommandLine.getAuthToken()).isEqualTo("auth123");
-    }
-
-    @Test
     public void testToolCommandLineAuthOptionMissingRequiredValue() {
         try {
-            toolCommandLine.applyArgs("-t");
+            toolCommandLine.applyArgs("-d");
             Assert.fail("Expected UsageException");
         } catch (UsageException e) {
-            assertThat(e.getMessage()).isEqualTo("Missing argument for option: t");
+            assertThat(e.getMessage()).isEqualTo("Missing argument for option: d");
         }
     }
 
@@ -226,15 +219,13 @@ public class ToolCommandLineTest {
         // one arg is present, no exception expected
         toolCommandLine.applyArgs(COMMAND_NAME,
             "-i", "input.txt",
-            "-o", "output.txt",
-            "-t", "auth-token-123");
+            "-o", "output.txt");
         toolCommandLine.validateCommand();
 
         // two commandMap present, expecting UsageException
         toolCommandLine.applyArgs(COMMAND_NAME, "generate-user-report",
             "-i", "input.txt",
-            "-o", "output.txt",
-            "-t", "auth-token-123");
+            "-o", "output.txt");
         try {
             toolCommandLine.validateCommand();
             Assert.fail("Expected UsageException to be thrown");
@@ -245,8 +236,7 @@ public class ToolCommandLineTest {
         // no command present, expecting UsageException
         toolCommandLine.applyArgs(
             "-i", "input.txt",
-            "-o", "output.txt",
-            "-t", "auth-token-123");
+            "-o", "output.txt");
         try {
             toolCommandLine.validateCommand();
             Assert.fail("Expected UsageException to be thrown");

--- a/src/test/java/org/opentestsystem/ap/timstool/commandline/ToolOptionsTest.java
+++ b/src/test/java/org/opentestsystem/ap/timstool/commandline/ToolOptionsTest.java
@@ -49,10 +49,9 @@ public class ToolOptionsTest {
     }
 
     @Test
-    public void getAuthToken() {
-        Option option = toolOptions.getAuthToken();
-        assertOptions(option, "t", "token", true, "Specifies the authorization token.");
-        assertThat(option.getArgName()).isEqualTo("auth-token");
+    public void getItemIds() {
+        Option option = toolOptions.getItemIds();
+        assertOptions(option, "d", "itemIds", true, "Specifies the item ids to create test packages for.");
     }
 
     private void assertOptions(Option option, String opt, String longOpt, boolean hasArg, String desc) {


### PR DESCRIPTION
…archive retrieval

Additionally, a token no longer needs to be provided for any of the commands. SSO info will need to be provided via spring properties/environment variables. The README is not updated with instructions as part of this PR, but will be updated shortly after.