### PR TITLE
 "updated common to 0.5.65"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ group=org.opentestsystem.ap
 
 version=0.5.34-SNAPSHOT
 
-commonVersion=0.5.64
+commonVersion=0.5.65
 
 # required when releasing - releaseFinish
 gitUser=


### PR DESCRIPTION
We bumped the common version in gradle.properties but there is no dependency on common in build.gradle.    So the tool at present does not use common for anything.  I would guess that to change at some point but maybe not.

I'm going to merge this given it doesn't change anything functional.