### PR TITLE
IAT-3480 IAT-3481: for package creation use -o as output dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,18 @@ Command: `create-test-package`
 Description: Creates an XML test package based on the input spreadsheet
 
 - `-i`: spreadsheet name
-- `-o`: file name to write results
+- `-o`: output directory to write results (defaults to current working directory)
+
+(Output file name will be created based on the package ID found in the input file.)
 
 Example usage and output from create-test-package:
 
 <pre>
-$ java -jar <jar-name>  create-test-package -i SBAC-IAB-FIXED-G11M-Winter-2017-2018.xlsx -o outputFile.xml
+$ java -jar <jar-name>  create-test-package -i SBAC-IAB-FIXED-G11M-Winter-2017-2018.xlsx -o .
 starting...
 
 validated..., submitting request to TIMS
-The results have been written to outputFile.xml
+The results have been written to ./SBAC-IAB-FIXED-G11M-AlgLin.xml
 
 complete
 </pre>

--- a/src/main/java/org/opentestsystem/ap/timstool/command/CreateTestPackageCommand.java
+++ b/src/main/java/org/opentestsystem/ap/timstool/command/CreateTestPackageCommand.java
@@ -14,6 +14,11 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import java.nio.file.Path;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.regex.Pattern.compile;
 
 /**
  * Calls the Test Management Service passing it an Excel spreadsheet.  The response is written to a file.
@@ -27,6 +32,12 @@ public class CreateTestPackageCommand implements Command {
     private final OAuth2RestOperations restTemplate;
 
     private final String commandName;
+
+    // Matcher for id attribute of TestPackage tag.
+    private static final Pattern PACKAGE_ID_REGEX =
+            compile("<TestPackage[^>]*id=\"([^\"]*)\"[^>]*>", Pattern.DOTALL);
+
+    private static final String EXTENSION = ".xml";
 
     public CreateTestPackageCommand(ToolProperties properties, OAuth2RestOperations restTemplate) {
         this.properties = properties;
@@ -60,16 +71,24 @@ public class CreateTestPackageCommand implements Command {
                 requestEntity,
                 String.class);
 
-        Path outputFile = commandLine.writeToOutputFile(response.getBody());
+        String packageId = extractPackageId(response.getBody(), commandLine::printCommandError);
+        Path outputFile = commandLine.writeToOutputFile(packageId + EXTENSION, response.getBody());
         commandLine.printMessage("The results have been written to %s", outputFile.toString());
+    }
+
+    private String extractPackageId(final String packageBody, final Consumer<String> errorHandler) {
+        Matcher matcher = PACKAGE_ID_REGEX.matcher(packageBody);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+
+        errorHandler.accept("Cannot extract Test Package ID.");
+        return "UNKNOWN_PACKAGE_ID";
     }
 
     private void validate(ToolCommandLine commandLine) {
         if (!commandLine.hasInputFile()) {
             throw new UsageException(String.format("Command %s requires an input file be specified.", commandName));
-        }
-        if (!commandLine.hasOutputFile()) {
-            throw new UsageException(String.format("Command %s requires an output file be specified.", commandName));
         }
     }
 }

--- a/src/main/java/org/opentestsystem/ap/timstool/commandline/ToolCommandLine.java
+++ b/src/main/java/org/opentestsystem/ap/timstool/commandline/ToolCommandLine.java
@@ -121,9 +121,10 @@ public class ToolCommandLine {
         return this.getOptionValue(this.toolOptions.getOutputFile());
     }
 
-    public Path writeToOutputFile(String content, OpenOption... options) {
-        String outputFileName = this.getOutputFile();
-        Path outputFilePath = Paths.get(outputFileName);
+    public Path writeToOutputFile(String fileName, String content, OpenOption... options) {
+        String outputDirectory = this.getOutputFile() == null ? "." : this.getOutputFile();
+
+        Path outputFilePath = Paths.get(outputDirectory, fileName);
         try {
             Files.write(outputFilePath, content.getBytes(), options);
             return outputFilePath;
@@ -148,7 +149,7 @@ public class ToolCommandLine {
             CONSOLE.println("Failed to write content to " + outputFilePath.toString());
             CONSOLE.println("--- BEGIN CONTENT ---");
             CONSOLE.println();
-            CONSOLE.println(content);
+            CONSOLE.println(new String(content));
             CONSOLE.println();
             CONSOLE.println("--- END CONTENT ---");
             throw new RuntimeException("Error writing to output file: " + e.getMessage(), e);

--- a/src/main/java/org/opentestsystem/ap/timstool/commandline/ToolOptions.java
+++ b/src/main/java/org/opentestsystem/ap/timstool/commandline/ToolOptions.java
@@ -52,7 +52,7 @@ public class ToolOptions {
 
         this.outputFile = Option.builder("o").longOpt("output")
             .hasArg().argName("file")
-            .desc("Specifies the output file.").build();
+            .desc("Specifies the output file or directory.").build();
 
         this.itemIds = Option.builder("d").longOpt("itemIds")
             .hasArg().argName("item-ids")

--- a/src/test/java/org/opentestsystem/ap/timstool/command/CreateTestPackageCommandTest.java
+++ b/src/test/java/org/opentestsystem/ap/timstool/command/CreateTestPackageCommandTest.java
@@ -8,10 +8,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.opentestsystem.ap.timstool.ToolProperties;
-import org.opentestsystem.ap.timstool.commandline.ToolCommandLine;
-import org.opentestsystem.ap.timstool.commandline.ToolCommands;
-import org.opentestsystem.ap.timstool.exception.UsageException;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +18,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.opentestsystem.ap.timstool.ToolProperties;
+import org.opentestsystem.ap.timstool.commandline.ToolCommandLine;
+import org.opentestsystem.ap.timstool.commandline.ToolCommands;
+import org.opentestsystem.ap.timstool.exception.UsageException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.eq;
@@ -31,10 +31,10 @@ import static org.mockito.Mockito.when;
 public class CreateTestPackageCommandTest {
 
     static final String COMMAND_NAME = CommandEnum.CreateTestPackage.getText();
+    static final String PACKAGE_ID = "test-package-id-xyz";
+    static final String OUTPUT_FILE_NAME = PACKAGE_ID + ".xml";
 
-    static final String OUTPUT_FILE_NAME = "output.xml";
-
-    static final Path OUT_PUT_FILE_PATH = Paths.get(OUTPUT_FILE_NAME);
+    static final Path OUTPUT_FILE_PATH = Paths.get(OUTPUT_FILE_NAME);
 
     ToolProperties toolProperties;
 
@@ -75,14 +75,15 @@ public class CreateTestPackageCommandTest {
     }
 
     void deleteOutputFile() throws IOException {
-        if (Files.exists(OUT_PUT_FILE_PATH)) {
-            Files.delete(OUT_PUT_FILE_PATH);
+        if (Files.exists(OUTPUT_FILE_PATH)) {
+            Files.delete(OUTPUT_FILE_PATH);
         }
     }
 
     @Test
     public void testExecuteSuccess() {
-        when(responseEntity.getBody()).thenReturn("<report>SUCCESS</report>");
+        when(responseEntity.getBody()).thenReturn(
+                "\n\n<TestPackage attr1=\"val1\"\nattr2=\"val2\" id=\"" + PACKAGE_ID + "\" />");
         when(
             restTemplate.postForEntity(
                 eq(String.format("%s/%s", toolProperties.getApiGatewayUrl(), toolProperties.getCreateTestManagementEndpoint())),
@@ -93,11 +94,11 @@ public class CreateTestPackageCommandTest {
         toolCommandLine.applyArgs(
             COMMAND_NAME,
             "-i", "input.txt",
-            "-o", "output.xml");
+            "-o", ".");
 
         command.execute(toolCommandLine);
 
-        assertThat(Files.exists(OUT_PUT_FILE_PATH)).isTrue();
+        assertThat(Files.exists(OUTPUT_FILE_PATH)).isTrue();
 
         assertThat(argumentCaptor.getValue().getHeaders().getContentType().toString()).isEqualTo("multipart/form-data");
 
@@ -117,10 +118,20 @@ public class CreateTestPackageCommandTest {
 
     @Test
     public void testWhenNoOutputFileOptionGiven() {
+        when(responseEntity.getBody()).thenReturn(
+                "\n\n<TestPackage attr1=\"val1\"\nattr2=\"val2\" id=\"" + PACKAGE_ID + "\" />");
+        when(
+            restTemplate.postForEntity(
+                eq(String.format("%s/%s", toolProperties.getApiGatewayUrl(), toolProperties.getCreateTestManagementEndpoint())),
+                argumentCaptor.capture(),
+                eq(String.class)))
+            .thenReturn(responseEntity);
+
         toolCommandLine.applyArgs(
             COMMAND_NAME,
             "-i", "input.txt");
-        assertCommandValidation(toolCommandLine, "Command create-test-package requires an output file be specified.");
+        command.execute(toolCommandLine);
+        assertThat(Files.exists(OUTPUT_FILE_PATH)).isTrue();
     }
 
     void assertCommandValidation(ToolCommandLine toolCommandLine, String expectedErrorMessage) {

--- a/src/test/java/org/opentestsystem/ap/timstool/commandline/ToolCommandLineTest.java
+++ b/src/test/java/org/opentestsystem/ap/timstool/commandline/ToolCommandLineTest.java
@@ -34,10 +34,9 @@ import static org.mockito.Mockito.when;
 public class ToolCommandLineTest {
 
     static final String COMMAND_NAME = CommandEnum.CreateTestPackage.getText();
-
+    static final String OUTPUT_DIRECTORY_NAME = ".";
     static final String OUTPUT_FILE_NAME = "output.xml";
-
-    static final Path OUT_PUT_FILE_PATH = Paths.get(OUTPUT_FILE_NAME);
+    static final Path OUTPUT_FILE_PATH = Paths.get(OUTPUT_DIRECTORY_NAME, OUTPUT_FILE_NAME);
 
     @Mock
     CommandLineParser commandLineParser;
@@ -78,8 +77,8 @@ public class ToolCommandLineTest {
     }
 
     void deleteOutputFile() throws IOException {
-        if (Files.exists(OUT_PUT_FILE_PATH)) {
-            Files.delete(OUT_PUT_FILE_PATH);
+        if (Files.exists(OUTPUT_FILE_PATH)) {
+            Files.delete(OUTPUT_FILE_PATH);
         }
     }
 
@@ -95,13 +94,27 @@ public class ToolCommandLineTest {
     }
 
     @Test
-    public void testWriteToOutputFile() {
-        assertThat(Files.exists(OUT_PUT_FILE_PATH)).isFalse();
-        toolCommandLine.applyArgs(COMMAND_NAME, "-o", OUTPUT_FILE_NAME);
-        toolCommandLine.writeToOutputFile("<item></item>");
-        assertThat(Files.exists(OUT_PUT_FILE_PATH)).isTrue();
+    public void testWriteStringToOutputFile() {
+        assertThat(Files.exists(OUTPUT_FILE_PATH)).isFalse();
+        toolCommandLine.applyArgs(COMMAND_NAME, "-o", OUTPUT_DIRECTORY_NAME);
+        toolCommandLine.writeToOutputFile(OUTPUT_FILE_NAME, "<item></item>");
+        assertThat(Files.exists(OUTPUT_FILE_PATH)).isTrue();
         try {
-            toolCommandLine.writeToOutputFile("<stim></stim>", CREATE_NEW);
+            toolCommandLine.writeToOutputFile(OUTPUT_FILE_NAME, "<stim></stim>", CREATE_NEW);
+            Assert.fail("Expected RuntimeException to be thrown");
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage()).isEqualTo("Error writing to output file: " + OUTPUT_FILE_PATH);
+        }
+    }
+
+    @Test
+    public void testWriteBytesToOutputFile() {
+        assertThat(Files.exists(OUTPUT_FILE_PATH)).isFalse();
+        toolCommandLine.applyArgs(COMMAND_NAME, "-o", OUTPUT_FILE_NAME);
+        toolCommandLine.writeToOutputFile("<item></item>".getBytes());
+        assertThat(Files.exists(OUTPUT_FILE_PATH)).isTrue();
+        try {
+            toolCommandLine.writeToOutputFile("<stim></stim>".getBytes(), CREATE_NEW);
             Assert.fail("Expected RuntimeException to be thrown");
         } catch (RuntimeException e) {
             assertThat(e.getMessage()).isEqualTo("Error writing to output file: " + OUTPUT_FILE_NAME);

--- a/src/test/java/org/opentestsystem/ap/timstool/commandline/ToolOptionsTest.java
+++ b/src/test/java/org/opentestsystem/ap/timstool/commandline/ToolOptionsTest.java
@@ -44,7 +44,7 @@ public class ToolOptionsTest {
     @Test
     public void getOutputFile() {
         Option option = toolOptions.getOutputFile();
-        assertOptions(option, "o", "output", true, "Specifies the output file.");
+        assertOptions(option, "o", "output", true, "Specifies the output file or directory.");
         assertThat(option.getArgName()).isEqualTo("file");
     }
 


### PR DESCRIPTION
-o should specify an output dir, the file name will come from the test package ID. 